### PR TITLE
feat: OS scheduler, headless mode, default date range, smart time picker

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,12 @@ repos:
       name: pytest (fast)
       entry: bash -c 'pytest -m fast || pytest'
       language: python
-      additional_dependencies: [pytest,pandas,requests]
+      additional_dependencies:
+        - pytest
+        - pandas
+        - requests
+        - customtkinter
+        - darkdetect
       pass_filenames: false
 
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/src/getbhavcopy/config.py
+++ b/src/getbhavcopy/config.py
@@ -40,3 +40,13 @@ def load_config() -> Any:
 def save_config(cfg: dict) -> None:
     path = get_config_path()
     path.write_text(json.dumps(cfg, indent=2))
+
+
+def is_newer(latest: str, current: str) -> bool:
+    """Return True if latest version is newer than current."""
+    try:
+        latest_parts = [int(x) for x in latest.strip().split(".")]
+        current_parts = [int(x) for x in current.strip().split(".")]
+        return latest_parts > current_parts
+    except Exception:
+        return False

--- a/src/getbhavcopy/scheduler.py
+++ b/src/getbhavcopy/scheduler.py
@@ -177,6 +177,12 @@ def _register_mac(enabled: bool, schedule_time: str) -> None:
     plist_path.parent.mkdir(parents=True, exist_ok=True)
     plist_path.write_text(plist)
 
+    # Unload first if already loaded — ensures fresh registration
+    subprocess.call(
+        ["launchctl", "unload", str(plist_path)],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
     subprocess.call(
         ["launchctl", "load", str(plist_path)],
         stdout=subprocess.DEVNULL,

--- a/src/getbhavcopy/settings_windows.py
+++ b/src/getbhavcopy/settings_windows.py
@@ -209,6 +209,16 @@ class SettingsWindow:
         self._nav_widgets: dict[str, dict] = {}
         self._on_save_callback = on_save
 
+        from tkinter import BooleanVar
+        from tkinter import StringVar as _SV
+
+        cfg = load_app_config()
+        self._schedule_enabled = BooleanVar(value=cfg.get("schedule_enabled", False))
+        _saved_time = cfg.get("schedule_time", "16:00")
+        _t = _saved_time.split(":") if ":" in _saved_time else ["16", "00"]
+        self._schedule_hour_var = _SV(value=_t[0].zfill(2))
+        self._schedule_min_var = _SV(value=_t[1].zfill(2))
+
         self._build_root()
         self._load_existing()
         if not self._rows:
@@ -260,12 +270,13 @@ class SettingsWindow:
 
         Frame(right, bg=self._p["SEP"], height=1).pack(fill="x")
 
+        # Footer must be packed BEFORE switcher so it is not pushed out
+        Frame(right, bg=self._p["SEP"], height=1).pack(fill="x", side="bottom")
+        self._build_footer(right)
+
         self._switcher = Frame(right, bg=self._p["CONTENT_BG"])
         self._switcher.pack(fill="both", expand=True)
         self._switcher.pack_propagate(False)
-
-        Frame(right, bg=self._p["SEP"], height=1).pack(fill="x", side="bottom")
-        self._build_footer(right)
 
         self._build_sidebar()
 
@@ -278,13 +289,16 @@ class SettingsWindow:
 
         pm = F(self._switcher, bg=self._p["CONTENT_BG"])
         pp = F(self._switcher, bg=self._p["CONTENT_BG"])
+        ps = F(self._switcher, bg=self._p["CONTENT_BG"])
 
-        for panel in (pm, pp):
+        for panel in (pm, pp, ps):
             panel.grid(row=0, column=0, sticky="nsew")
 
         self._build_panel_mapping(pm)
         self._build_panel_performance(pp)
-        self._panels = {"mapping": pm, "performance": pp}
+        self._build_panel_scheduler(ps)
+        self._setup_time_validators()
+        self._panels = {"mapping": pm, "performance": pp, "scheduler": ps}
 
         self._build_topbar("mapping")
         self.win.after(10, lambda: self._switch("mapping"))
@@ -351,7 +365,8 @@ class SettingsWindow:
             ("output", "Output"),
             ("appearance", "Appearance"),
         ]:
-            self._nav_item(key, label, disabled=True)
+            disabled = key != "scheduler"
+            self._nav_item(key, label, disabled=disabled)
 
     def _nav_item(self, key: str, label: str, disabled: bool) -> None:
         from tkinter import Frame, Label
@@ -468,7 +483,12 @@ class SettingsWindow:
                 "Performance",
                 "Configure download speed and threading behaviour",
             ),
+            "scheduler": (
+                "Scheduler",
+                "Auto-download today's bhavcopy at a set time every day",
+            ),
         }
+
         title, sub = titles.get(key, (key.title(), ""))
 
         Frame(self._topbar, bg=self._p["CONTENT_BG"], height=22).pack()
@@ -717,6 +737,151 @@ class SettingsWindow:
             justify="left",
         ).pack(anchor="w")
 
+    def _build_panel_scheduler(self, parent: object) -> None:
+        from tkinter import Frame, Label
+
+        outer = Frame(parent, bg=self._p["CONTENT_BG"])  # type: ignore[arg-type]
+        outer.pack(fill="both", expand=True, padx=28, pady=20)
+
+        # Enable card
+        enable_card = Frame(
+            outer,
+            bg=self._p["CARD_BG"],
+            highlightbackground=self._p["SEP"],
+            highlightthickness=1,
+            padx=22,
+            pady=18,
+        )
+        enable_card.pack(fill="x")
+
+        enable_row = Frame(enable_card, bg=self._p["CARD_BG"])
+        enable_row.pack(fill="x", pady=(0, 6))
+
+        Label(
+            enable_row,
+            text="Enable Scheduled Downloads",
+            font=(self.FONT, 13, "bold"),
+            fg=self._p["FG1"],
+            bg=self._p["CARD_BG"],
+        ).pack(side="left")
+
+        ctk.CTkSwitch(
+            enable_row,
+            text="",
+            variable=self._schedule_enabled,
+            onvalue=True,
+            offvalue=False,
+            button_color=self._p["ACCENT"],
+            progress_color=self._p["ACCENT"],
+        ).pack(side="right")
+
+        Label(
+            enable_card,
+            text="Automatically download today's bhavcopy at the time set below.\n"
+            "No need to open the app — the OS handles it automatically.",
+            font=(self.FONT, 11),
+            fg=self._p["FG3"],
+            bg=self._p["CARD_BG"],
+            justify="left",
+            anchor="w",
+        ).pack(anchor="w")
+
+        # Time card
+        time_card = Frame(
+            outer,
+            bg=self._p["CARD_BG"],
+            highlightbackground=self._p["SEP"],
+            highlightthickness=1,
+            padx=22,
+            pady=18,
+        )
+        time_card.pack(fill="x", pady=(12, 0))
+
+        time_row = Frame(time_card, bg=self._p["CARD_BG"])
+        time_row.pack(fill="x", pady=(0, 6))
+
+        Label(
+            time_row,
+            text="Download Time",
+            font=(self.FONT, 13, "bold"),
+            fg=self._p["FG1"],
+            bg=self._p["CARD_BG"],
+        ).pack(side="left")
+
+        time_fields = ctk.CTkFrame(time_row, fg_color=self._p["CARD_BG"])
+        time_fields.pack(side="right")
+
+        self._hour_entry = ctk.CTkEntry(
+            time_fields,
+            textvariable=self._schedule_hour_var,
+            width=52,
+            font=(self.FONT, 14, "bold"),
+            justify="center",
+            fg_color=self._p["ENTRY_BG"],
+            text_color=self._p["ACCENT"],
+            border_color=self._p["ACCENT"],
+            border_width=2,
+            corner_radius=8,
+        )
+        self._hour_entry.pack(side="left")
+
+        ctk.CTkLabel(
+            time_fields,
+            text=":",
+            font=(self.FONT, 16, "bold"),
+            text_color=self._p["FG1"],
+            fg_color=self._p["CARD_BG"],
+            width=12,
+        ).pack(side="left")
+
+        self._min_entry = ctk.CTkEntry(
+            time_fields,
+            textvariable=self._schedule_min_var,
+            width=52,
+            font=(self.FONT, 14, "bold"),
+            justify="center",
+            fg_color=self._p["ENTRY_BG"],
+            text_color=self._p["ACCENT"],
+            border_color=self._p["ACCENT"],
+            border_width=2,
+            corner_radius=8,
+        )
+        self._min_entry.pack(side="left")
+
+        Label(
+            time_card,
+            text="Click the time field on the right to edit — use 24hr format.\n"
+            "NSE closes at 15:30 IST so 16:00 or later is recommended.",
+            font=(self.FONT, 11),
+            fg=self._p["FG3"],
+            bg=self._p["CARD_BG"],
+            justify="left",
+            anchor="w",
+        ).pack(anchor="w")
+
+        # Info box
+        info = Frame(
+            outer,
+            bg=self._p["INFO_BG"],
+            highlightbackground=self._p["INFO_BORDER"],
+            highlightthickness=1,
+            padx=16,
+            pady=12,
+        )
+        info.pack(fill="x", pady=(16, 0))
+
+        Label(
+            info,
+            text="Uses OS-level scheduling — works even when the app is closed. "
+            "Mac uses LaunchAgent, Windows uses Task Scheduler, "
+            "Linux uses crontab.",
+            font=(self.FONT, 11),
+            fg=self._p["INFO_FG"],
+            bg=self._p["INFO_BG"],
+            wraplength=480,
+            justify="left",
+        ).pack(anchor="w")
+
     # ── footer ────────────────────────────────────────────────────────────────
     def _build_footer(self, parent: object) -> None:
         from tkinter import Frame
@@ -754,6 +919,41 @@ class SettingsWindow:
             width=130,
             command=self.save_mapping,
         ).pack(side="right")
+
+    def _setup_time_validators(self) -> None:
+        self._schedule_hour_var.trace("w", self._limit_hour)
+        self._schedule_min_var.trace("w", self._limit_min)
+
+    def _limit_hour(self, *args: object) -> None:
+        v = self._schedule_hour_var.get()
+        if not v.isdigit():
+            self._schedule_hour_var.set("".join(c for c in v if c.isdigit()))
+            return
+        if len(v) > 2:
+            self._schedule_hour_var.set(v[:2])
+            return
+        if len(v) == 2:
+            h = int(v)
+            if h > 23:
+                self._schedule_hour_var.set("23")
+            else:
+                # Auto advance to minutes
+                if hasattr(self, "_min_entry"):
+                    self._min_entry.focus()
+                    self._min_entry.icursor("end")
+
+    def _limit_min(self, *args: object) -> None:
+        v = self._schedule_min_var.get()
+        if not v.isdigit():
+            self._schedule_min_var.set("".join(c for c in v if c.isdigit()))
+            return
+        if len(v) > 2:
+            self._schedule_min_var.set(v[:2])
+            return
+        if len(v) == 2:
+            m = int(v)
+            if m > 59:
+                self._schedule_min_var.set("59")
 
     # ── row management ────────────────────────────────────────────────────────
     def _refresh_count(self) -> None:
@@ -846,11 +1046,15 @@ class SettingsWindow:
         try:
             cfg = load_app_config()
             cfg["max_workers"] = int(self._workers_var.get())
+            cfg["schedule_enabled"] = bool(self._schedule_enabled.get())
+            h = self._schedule_hour_var.get().zfill(2)
+            m = self._schedule_min_var.get().zfill(2)
+            cfg["schedule_time"] = f"{h}:{m}"
             save_app_config(cfg)
             save_symbol_mapping(mapping)
-            self._on_close()
             if self._on_save_callback:
                 getattr(self._on_save_callback, "__call__")()
+            self._on_close()
         except Exception as e:
             messagebox.showerror("Save Failed", str(e))
 

--- a/src/getbhavcopy/ui.py
+++ b/src/getbhavcopy/ui.py
@@ -19,11 +19,12 @@ from tkinter import StringVar, filedialog, messagebox
 
 import customtkinter as ctk
 
+from getbhavcopy.config import is_newer as _is_newer
 from getbhavcopy.config import load_config, save_config
 from getbhavcopy.core import GetBhavCopy
 from getbhavcopy.logging_config import setup_logging
 from getbhavcopy.notifications import send_notification
-from getbhavcopy.scheduler import register_autostart, register_os_scheduler
+from getbhavcopy.scheduler import register_os_scheduler
 from getbhavcopy.settings_windows import SettingsWindow
 
 ctk.set_appearance_mode("system")
@@ -44,15 +45,6 @@ def open_folder(path: Path) -> None:
             subprocess.call(["xdg-open", str(path)])
     except Exception as e:
         logger.error(f"Could not open folder automatically: {e}")
-
-
-def _is_newer(latest: str, current: str) -> bool:
-    try:
-        latest_parts = [int(x) for x in latest.strip().split(".")]
-        current_parts = [int(x) for x in current.strip().split(".")]
-        return latest_parts > current_parts
-    except Exception:
-        return False
 
 
 class TkinterLogHandler(logging.Handler):
@@ -160,12 +152,6 @@ class App:
         logger.info("UI logging initialized successfully.")
         self.root.after(3000, self._check_for_updates)
 
-        # Start in-app scheduler loop (fallback when OS scheduler is not set)
-        self._start_in_app_scheduler()
-
-        # Apply autostart setting from config
-        self._apply_autostart()
-
     # ── theme ─────────────────────────────────────────────────────────────────
 
     def _c(self, key: str) -> str:
@@ -187,50 +173,13 @@ class App:
     def run(self) -> None:
         self.root.mainloop()
 
-    # ── scheduler ─────────────────────────────────────────────────────────────
-
-    def _start_in_app_scheduler(self) -> None:
-        """
-        Fallback scheduler — runs while the app is open.
-        The OS-level scheduler (LaunchAgent / Task Scheduler / cron)
-        is the primary mechanism and works without the app being open.
-        """
-        thread = threading.Thread(target=self._in_app_scheduler_loop, daemon=True)
-        thread.start()
-
-    def _in_app_scheduler_loop(self) -> None:
-        import time
-
-        last_triggered = ""
-        while True:
-            try:
-                cfg = load_config()
-                if cfg.get("schedule_enabled", False):
-                    schedule_time = cfg.get("schedule_time", "16:00").strip()
-                    now = datetime.now().strftime("%H:%M")
-                    today = datetime.now().strftime("%Y-%m-%d")
-                    trigger_key = f"{today}_{schedule_time}"
-                    if now == schedule_time and last_triggered != trigger_key:
-                        last_triggered = trigger_key
-                        logger.info(f"In-app scheduler triggered at {now}")
-                        self.root.after(0, self._start_download)
-            except Exception:
-                pass
-            time.sleep(30)
-
-    def _apply_autostart(self) -> None:
-        enabled = self._cfg.get("autostart_enabled", False)
-        register_autostart(enabled)
-
     def _on_settings_saved(self) -> None:
         """Called by SettingsWindow after user saves — syncs OS scheduler."""
         cfg = load_config()
         enabled = cfg.get("schedule_enabled", False)
         schedule_time = cfg.get("schedule_time", "16:00")
-        autostart = cfg.get("autostart_enabled", False)
 
         register_os_scheduler(enabled, schedule_time)
-        register_autostart(autostart)
 
         status = "enabled" if enabled else "disabled"
         logger.info(f"OS scheduler {status} for {schedule_time} daily")

--- a/tests/test_getbhavcopy.py
+++ b/tests/test_getbhavcopy.py
@@ -1,75 +1,382 @@
-from unittest.mock import patch
+"""
+tests/test_getbhavcopy.py — full test suite for GetBhavCopy.
+
+Covers:
+  - core download engine
+  - config read/write
+  - scheduler registration
+  - headless mode
+  - symbol mapping
+  - notifications
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from getbhavcopy.core import GetBhavCopy
 
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+EQUITY_CSV = (
+    "SYMBOL,OPEN_PRICE,HIGH_PRICE,LOW_PRICE,CLOSE_PRICE,TTL_TRD_QNTY\n"
+    "RELIANCE,100,110,90,105,1000\n"
+    "INFY,1500,1550,1480,1520,500\n"
+)
+
+INDICES_CSV = (
+    "INDEX NAME,INDEX DATE,OPEN INDEX VALUE,HIGH INDEX VALUE,"
+    "LOW INDEX VALUE,CLOSING INDEX VALUE,VOLUME\n"
+    "Nifty 50,13-02-2026,20000,20200,19800,20100,5000\n"
+)
+
 
 class FakeResp:
-    def __init__(self, text, status_code=200):
+    def __init__(self, text: str, status_code: int = 200) -> None:
         self.text = text
         self.status_code = status_code
 
 
-def fake_requests_get(url, timeout=15):
+def fake_session_get(url: str, timeout: int = 15) -> FakeResp:
     if "sec_bhavdata_full" in url:
-        return FakeResp(
-            "SYMBOL,OPEN_PRICE,HIGH_PRICE,LOW_PRICE,CLOSE_PRICE,TTL_TRD_QNTY\n"
-            "RELIANCE,100,110,90,105,1000\n"
-        )
-
+        return FakeResp(EQUITY_CSV)
     if "ind_close_all" in url:
-        return FakeResp(
-            "SYMBOL,OPEN_PRICE,HIGH_PRICE,LOW_PRICE,CLOSE_PRICE,TTL_TRD_QNTY\n"
-            "NIFTY 50,2026-02-13,20000,20200,19800,20100,5000\n"
-        )
-
+        return FakeResp(INDICES_CSV)
     return FakeResp("", 404)
 
 
-def test_start_date_after_end_date_raises():
-    b = GetBhavCopy(
-        "2026-02-10",
-        "2026-02-01",
-        "DATA",
-        "TXT",
-        None,
-        None,
-    )
+# ── Core — date validation ────────────────────────────────────────────────────
 
+
+def test_start_date_after_end_date_raises() -> None:
+    b = GetBhavCopy("2026-02-10", "2026-02-01", "DATA", "TXT", None, None)
     with pytest.raises(ValueError):
         b.get_bhavcopy()
 
 
-@patch("getbhavcopy.core.requests.Session.get", side_effect=fake_requests_get)
-def test_file_created_on_success(_mock_get, tmp_path):
+def test_same_start_end_date_valid(tmp_path: Path) -> None:
+    with patch(
+        "getbhavcopy.core.requests.Session.get",
+        side_effect=fake_session_get,
+    ):
+        b = GetBhavCopy("2026-02-13", "2026-02-13", str(tmp_path), "TXT", None, None)
+        b.get_bhavcopy()
+        assert b.failed_dates == []
 
-    save_dir = tmp_path / "data"
 
-    b = GetBhavCopy(
-        "2026-02-13",
-        "2026-02-13",
-        str(save_dir),
-        "TXT",
-        None,
-        None,
-    )
+# ── Core — file creation ──────────────────────────────────────────────────────
 
+
+@patch("getbhavcopy.core.requests.Session.get", side_effect=fake_session_get)
+def test_txt_file_created_on_success(_mock: MagicMock, tmp_path: Path) -> None:
+    b = GetBhavCopy("2026-02-13", "2026-02-13", str(tmp_path), "TXT", None, None)
     b.get_bhavcopy()
+    files = list(tmp_path.glob("*.txt"))
+    assert len(files) == 1
+    assert "2026-02-13" in files[0].name
+
+
+@patch("getbhavcopy.core.requests.Session.get", side_effect=fake_session_get)
+def test_csv_file_created_on_success(_mock: MagicMock, tmp_path: Path) -> None:
+    b = GetBhavCopy("2026-02-13", "2026-02-13", str(tmp_path), "CSV", None, None)
+    b.get_bhavcopy()
+    files = list(tmp_path.glob("*.csv"))
+    assert len(files) == 1
+
+
+@patch("getbhavcopy.core.requests.Session.get", side_effect=fake_session_get)
+def test_file_content_has_correct_columns(_mock: MagicMock, tmp_path: Path) -> None:
+    b = GetBhavCopy("2026-02-13", "2026-02-13", str(tmp_path), "TXT", None, None)
+    b.get_bhavcopy()
+    files = list(tmp_path.glob("*.txt"))
+    content = files[0].read_text()
+    # Should have SYMBOL,DATE,OPEN,HIGH,LOW,CLOSE,VOLUME — no header
+    first_line = content.strip().splitlines()[0]
+    parts = first_line.split(",")
+    assert len(parts) == 7
+
+
+# ── Core — skip existing ──────────────────────────────────────────────────────
+
+
+@patch("getbhavcopy.core.requests.Session.get", side_effect=fake_session_get)
+def test_existing_file_is_skipped(_mock: MagicMock, tmp_path: Path) -> None:
+    existing = tmp_path / "2026-02-13-NSE-EQ.txt"
+    existing.write_text("already exists")
+    b = GetBhavCopy("2026-02-13", "2026-02-13", str(tmp_path), "TXT", None, None)
+    b.get_bhavcopy()
+    # File content should not have changed
+    assert existing.read_text() == "already exists"
+
+
+# ── Core — failed dates ───────────────────────────────────────────────────────
 
 
 @patch("getbhavcopy.core.requests.Session.get", return_value=FakeResp("", 404))
-def test_404_results_in_no_file(_mock_get, tmp_path):
-
-    save_dir = tmp_path / "data"
-
-    b = GetBhavCopy(
-        "2026-02-13",
-        "2026-02-13",
-        str(save_dir),
-        "TXT",
-        None,
-        None,
-    )
-
+def test_404_recorded_in_failed_dates(_mock: MagicMock, tmp_path: Path) -> None:
+    b = GetBhavCopy("2026-02-13", "2026-02-13", str(tmp_path), "TXT", None, None)
     b.get_bhavcopy()
+    assert "2026-02-13" in b.failed_dates
+
+
+@patch("getbhavcopy.core.requests.Session.get", return_value=FakeResp("", 404))
+def test_404_does_not_create_file(_mock: MagicMock, tmp_path: Path) -> None:
+    b = GetBhavCopy("2026-02-13", "2026-02-13", str(tmp_path), "TXT", None, None)
+    b.get_bhavcopy()
+    assert list(tmp_path.glob("*.txt")) == []
+
+
+# ── Core — weekends skipped ───────────────────────────────────────────────────
+
+
+@patch("getbhavcopy.core.requests.Session.get", side_effect=fake_session_get)
+def test_weekend_dates_skipped(_mock: MagicMock, tmp_path: Path) -> None:
+    # 2026-02-14 is a Saturday, 2026-02-15 is a Sunday
+    b = GetBhavCopy("2026-02-14", "2026-02-15", str(tmp_path), "TXT", None, None)
+    b.get_bhavcopy()
+    assert list(tmp_path.glob("*.txt")) == []
+
+
+# ── Core — symbol mapping ─────────────────────────────────────────────────────
+
+
+@patch("getbhavcopy.core.requests.Session.get", side_effect=fake_session_get)
+def test_symbol_mapping_applied(_mock: MagicMock, tmp_path: Path) -> None:
+    b = GetBhavCopy("2026-02-13", "2026-02-13", str(tmp_path), "TXT", None, None)
+    b._symbol_mapping = {"RELIANCE": "REL"}
+    b.get_bhavcopy()
+    files = list(tmp_path.glob("*.txt"))
+    content = files[0].read_text()
+    assert "REL," in content
+    assert "RELIANCE," not in content
+
+
+# ── Config ────────────────────────────────────────────────────────────────────
+
+
+def test_load_config_creates_default(tmp_path: Path) -> None:
+    from getbhavcopy import config as cfg_module
+
+    fake_path = tmp_path / "SaveDirPath.json"
+    with patch.object(cfg_module, "get_config_path", return_value=fake_path):
+        result = cfg_module.load_config()
+    assert "DirPath" in result
+    assert "theme" in result
+    assert "format" in result
+    assert "schedule_enabled" in result
+    assert fake_path.exists()
+
+
+def test_save_and_reload_config(tmp_path: Path) -> None:
+    from getbhavcopy import config as cfg_module
+
+    fake_path = tmp_path / "SaveDirPath.json"
+    with patch.object(cfg_module, "get_config_path", return_value=fake_path):
+        cfg_module.save_config({"theme": "dark", "format": "CSV"})
+        result = cfg_module.load_config()
+    assert result["theme"] == "dark"
+    assert result["format"] == "CSV"
+
+
+def test_config_path_uses_appdata_on_windows(tmp_path: Path) -> None:
+    from getbhavcopy import config as cfg_module
+
+    with patch.dict("os.environ", {"APPDATA": str(tmp_path)}):
+        with patch("sys.platform", "win32"):
+            path = cfg_module.get_config_path()
+    assert "GetBhavCopy" in str(path)
+
+
+def test_config_path_uses_home_on_mac(tmp_path: Path) -> None:
+    from getbhavcopy import config as cfg_module
+
+    with patch.dict("os.environ", {}, clear=True):
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            path = cfg_module.get_config_path()
+    assert ".getbhavcopy" in str(path)
+
+
+# ── Symbol mapping ────────────────────────────────────────────────────────────
+
+
+def test_load_symbol_mapping_empty(tmp_path: Path) -> None:
+    from getbhavcopy import settings_windows as sw
+
+    with patch.object(sw, "get_mapping_path", return_value=tmp_path / "x.json"):
+        result = sw.load_symbol_mapping()
+    assert result == {}
+
+
+def test_save_and_load_symbol_mapping(tmp_path: Path) -> None:
+    from getbhavcopy import settings_windows as sw
+
+    fake_path = tmp_path / "symbol_mapping.json"
+    with patch.object(sw, "get_mapping_path", return_value=fake_path):
+        sw.save_symbol_mapping({"NIFTY 50": "NIFTY50", "reliance": "REL"})
+        result = sw.load_symbol_mapping()
+
+    # Keys should be uppercased
+    assert result["NIFTY 50"] == "NIFTY50"
+    assert result["RELIANCE"] == "REL"
+
+
+def test_symbol_mapping_ignores_empty_values(tmp_path: Path) -> None:
+    from getbhavcopy import settings_windows as sw
+
+    fake_path = tmp_path / "symbol_mapping.json"
+    fake_path.write_text(json.dumps({"NIFTY 50": "NIFTY50", "": "empty", "INFY": ""}))
+    with patch.object(sw, "get_mapping_path", return_value=fake_path):
+        result = sw.load_symbol_mapping()
+    assert "" not in result
+    assert "INFY" not in result
+
+
+# ── Scheduler ─────────────────────────────────────────────────────────────────
+
+
+def test_register_os_scheduler_mac_creates_plist(tmp_path: Path) -> None:
+    from getbhavcopy import scheduler
+
+    plist_path = tmp_path / "test.plist"
+    with patch.object(scheduler, "_MAC_PLIST_SCHEDULER", plist_path):
+        with patch("subprocess.call"):
+            scheduler._register_mac(True, "16:00")
+    assert plist_path.exists()
+    content = plist_path.read_text()
+    assert "<integer>16</integer>" in content
+    assert "<integer>0</integer>" in content
+    assert "--headless" in content
+
+
+def test_register_os_scheduler_mac_removes_plist(tmp_path: Path) -> None:
+    from getbhavcopy import scheduler
+
+    plist_path = tmp_path / "test.plist"
+    plist_path.write_text("dummy")
+    with patch.object(scheduler, "_MAC_PLIST_SCHEDULER", plist_path):
+        with patch("subprocess.call"):
+            scheduler._register_mac(False, "16:00")
+    assert not plist_path.exists()
+
+
+def test_register_linux_cron_enabled(tmp_path: Path) -> None:
+    from getbhavcopy import scheduler
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout="")
+        with patch("subprocess.Popen") as mock_popen:
+            mock_proc = MagicMock()
+            mock_popen.return_value = mock_proc
+            scheduler._register_linux(True, "16:00")
+            written = mock_proc.communicate.call_args[0][0].decode()
+            assert "getbhavcopy --headless" in written
+            assert "16" in written
+
+
+def test_register_linux_cron_disabled(tmp_path: Path) -> None:
+    from getbhavcopy import scheduler
+
+    existing = "0 16 * * 1-5 python -m getbhavcopy --headless # GetBhavCopy scheduler\n"
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout=existing)
+        with patch("subprocess.Popen") as mock_popen:
+            mock_proc = MagicMock()
+            mock_popen.return_value = mock_proc
+            scheduler._register_linux(False, "16:00")
+            written = mock_proc.communicate.call_args[0][0].decode()
+            assert "getbhavcopy --headless" not in written
+
+
+# ── Notifications ─────────────────────────────────────────────────────────────
+
+
+def test_send_notification_mac_calls_osascript() -> None:
+    from getbhavcopy import notifications
+
+    with patch("subprocess.call") as mock_call:
+        with patch("sys.platform", "darwin"):
+            notifications._notify_mac("Title", "Message")
+        mock_call.assert_called_once()
+        args = mock_call.call_args[0][0]
+        assert "osascript" in args
+        assert "Message" in args[2]
+
+
+def test_send_notification_linux_calls_notify_send() -> None:
+    from getbhavcopy import notifications
+
+    with patch("subprocess.call") as mock_call:
+        notifications._notify_linux("Title", "Message")
+        mock_call.assert_called_once()
+        args = mock_call.call_args[0][0]
+        assert "notify-send" in args
+
+
+def test_send_notification_silent_on_failure() -> None:
+    from getbhavcopy import notifications
+
+    # Should not raise even if subprocess fails
+    with patch("subprocess.call", side_effect=Exception("no subprocess")):
+        notifications.send_notification("Title", "Message")
+
+
+# ── Headless mode ─────────────────────────────────────────────────────────────
+def test_headless_exits_when_scheduler_disabled(tmp_path: Path) -> None:
+    from getbhavcopy import __main__ as main_module
+
+    with patch(
+        "getbhavcopy.config.load_config",
+        return_value={"schedule_enabled": False},
+    ):
+        main_module._run_headless()
+
+
+def test_headless_downloads_when_enabled(tmp_path: Path) -> None:
+    from getbhavcopy import __main__ as main_module
+
+    cfg = {
+        "schedule_enabled": True,
+        "DirPath": str(tmp_path),
+        "format": "TXT",
+    }
+    with patch("getbhavcopy.config.load_config", return_value=cfg):
+        with patch("getbhavcopy.core.GetBhavCopy") as mock_downloader:
+            mock_instance = MagicMock()
+            mock_instance.failed_dates = []
+            mock_downloader.return_value = mock_instance
+            with patch("getbhavcopy.notifications.send_notification"):
+                main_module._run_headless()
+            mock_instance.get_bhavcopy.assert_called_once()
+
+
+# ── is_newer version check ────────────────────────────────────────────────────
+
+
+def test_is_newer_returns_true_for_newer_version() -> None:
+    from getbhavcopy.config import is_newer as _is_newer
+
+    assert _is_newer("1.0.10", "1.0.9") is True
+    assert _is_newer("2.0.0", "1.9.9") is True
+    assert _is_newer("1.0.9.1", "1.0.9") is True
+
+
+def test_is_newer_returns_false_for_same_version() -> None:
+    from getbhavcopy.config import is_newer as _is_newer
+
+    assert _is_newer("1.0.9", "1.0.9") is False
+
+
+def test_is_newer_returns_false_for_older_version() -> None:
+    from getbhavcopy.config import is_newer as _is_newer
+
+    assert _is_newer("1.0.8", "1.0.9") is False
+    assert _is_newer("1.0.9", "1.0.9.1") is False
+
+
+def test_is_newer_handles_bad_input() -> None:
+    from getbhavcopy.config import is_newer as _is_newer
+
+    assert _is_newer("", "1.0.9") is False
+    assert _is_newer("not-a-version", "1.0.9") is False


### PR DESCRIPTION
- OS-level scheduler — LaunchAgent on Mac, Task Scheduler on Windows, cron on Linux
- Headless mode — python -m getbhavcopy --headless for silent background download
- Scheduler panel in Settings with enable toggle and smart HH:MM time picker
- Time picker auto-advances from hours to minutes, restricts invalid input
- Default date range saved and restored on next launch
- Desktop notification after scheduled download completes
- Removed in-app scheduler loop — OS handles all scheduling
- 30 tests passing — core, config, scheduler, notifications, headless

Closes #87
Closes #88

## Type of change
- [x] New feature
- [x] Refactor (no behaviour change)

## Checklist
- [x] `pre-commit run` passes
- [x] `pytest` passes
- [x] Tested on Mac or Windows
