### PR TITLE
fix: replace win10toast with winotify for Windows notifications

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,3 +51,6 @@ ignore_missing_imports = true
 testpaths = ["tests"]
 addopts = "--cov=getbhavcopy --cov-report=term-missing --cov-fail-under=20"
 pythonpath = ["src"]
+
+[project.optional-dependencies]
+windows = ["winotify"]

--- a/src/getbhavcopy/notifications.py
+++ b/src/getbhavcopy/notifications.py
@@ -3,6 +3,11 @@ notifications.py — cross-platform desktop notification support.
 
 Sends native notifications on Mac, Windows and Linux.
 All methods are silent on failure — notifications are best-effort only.
+
+Windows priority order:
+  1. winotify  — modern Windows 10/11 native API, no admin required
+  2. win10toast — legacy fallback
+  3. PowerShell — last resort, always works
 """
 
 import logging
@@ -35,10 +40,55 @@ def _notify_mac(title: str, message: str) -> None:
 
 
 def _notify_windows(title: str, message: str) -> None:
+    # Try winotify first — modern, no admin, works on Win10/11
+    try:
+        from winotify import Notification, audio
+
+        toast = Notification(
+            app_id="GetBhavCopy",
+            title=title,
+            msg=message,
+            duration="short",
+        )
+        toast.set_audio(audio.Default, loop=False)
+        toast.show()
+        return
+    except Exception:
+        pass
+
+    # Fallback 1 — win10toast legacy
     try:
         from win10toast import ToastNotifier
 
         ToastNotifier().show_toast(title, message, duration=5, threaded=True)
+        return
+    except Exception:
+        pass
+
+    # Fallback 2 — PowerShell, always works on any Windows
+    # Fallback 2 — PowerShell, always works on any Windows
+    try:
+        ns = "Windows.UI.Notifications"
+        mgr = f"[{ns}.ToastNotificationManager, {ns}, ContentType=WindowsRuntime]"
+        tmpl = f"[{ns}.ToastTemplateType]::ToastText02"
+        notif = f"[{ns}.ToastNotification]"
+        t0 = "$x.GetElementsByTagName('text')[0]"
+        t1 = "$x.GetElementsByTagName('text')[1]"
+        ps_script = (
+            f"{mgr} | Out-Null; "
+            f"$t = {tmpl}; "
+            f"$x = [{ns}.ToastNotificationManager]::GetTemplateContent($t); "
+            f"{t0}.AppendChild($x.CreateTextNode('{title}')) | Out-Null; "
+            f"{t1}.AppendChild($x.CreateTextNode('{message}')) | Out-Null; "
+            f"$n = {notif}::new($x); "
+            f"[{ns}.ToastNotificationManager]"
+            f"::CreateToastNotifier('GetBhavCopy').Show($n)"
+        )
+        subprocess.call(
+            ["powershell", "-WindowStyle", "Hidden", "-Command", ps_script],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
     except Exception:
         pass
 


### PR DESCRIPTION
## What does this PR do?
A clear description of the changes.

## Type of change
- [x] Bug fix - Windows Notification 

## Checklist
- [x] `pre-commit run` passes
- [x] `pytest` passes
